### PR TITLE
12 adding english translation and correct name of company foe link preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
     <meta property="twitter:description" content="day one mediagroup - Invest in the European answer to super apps. Combining e-commerce, social media & communication in one app." />
     <meta property="twitter:image" content="%PUBLIC_URL%/images/logo/logo.png" />
     
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/images/logo/Favicon.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/images/logo/logo.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,23 @@
     <meta name="theme-color" content="#2563eb" />
     <meta
       name="description"
-      content="One Media Company - Invest in the European answer to super apps. Combining e-commerce, social media & communication in one app."
+      content="day one mediagroup - Invest in the European answer to super apps. Combining e-commerce, social media & communication in one app."
     />
+    
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://dayone-mediagroup.com/" />
+    <meta property="og:title" content="day one mediagroup" />
+    <meta property="og:description" content="day one mediagroup - Invest in the European answer to super apps. Combining e-commerce, social media & communication in one app." />
+    <meta property="og:image" content="%PUBLIC_URL%/images/logo/logo.png" />
+    
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://dayone-mediagroup.com/" />
+    <meta property="twitter:title" content="day one mediagroup" />
+    <meta property="twitter:description" content="day one mediagroup - Invest in the European answer to super apps. Combining e-commerce, social media & communication in one app." />
+    <meta property="twitter:image" content="%PUBLIC_URL%/images/logo/logo.png" />
+    
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/images/logo/Favicon.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "One Media Company",
-  "name": "One Media Company - Investor Relations",
+  "short_name": "day one mediagroup",
+  "name": "day one mediagroup - Investor Relations",
   "icons": [
     {
       "src": "images/logo/Favicon.png",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -128,7 +128,7 @@
     },
     "cta": {
       "title": "Ready for Investment",
-      "description": "With proven traction and a scalable platform, we're ready to accelerate growth with strategic investment partners."
+      "description": "With proven traction and a scalable platform, we are accelerating growth – together with visionary investment partners. With TRADEFOOX, you will write the next global success story. This is more than an investment: you are shaping the next digital giant from Europe."
     }
   },
   "team": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -128,7 +128,11 @@
     },
     "cta": {
       "title": "Ready for Investment",
-      "description": "With proven traction and a scalable platform, we are accelerating growth – together with visionary investment partners. With TRADEFOOX, you will write the next global success story. This is more than an investment: you are shaping the next digital giant from Europe."
+      "description": [
+        "With proven traction and a scalable platform, we are accelerating growth together with visionary investment partners.",
+        "With TRADEFOOX, you will write the next global success story.",
+        "This is more than an investment: you are shaping the next digital giant from Europe."
+      ]
     }
   },
   "team": {


### PR DESCRIPTION
Update company branding from "One Media Company" to "day one mediagroup" across all meta tags and web app manifest

**Changes:**
- Update HTML title to use proper company name "day one mediagroup"
- Add Open Graph meta tags for better social media link previews
- Add Twitter Card meta tags for Twitter link previews
- Update web app manifest short_name and name fields
- Update meta description to use correct company name

**Files Modified:**
- `public/index.html` - Added Open Graph and Twitter meta tags, updated description
- `public/manifest.json` - Updated company name in PWA manifest

**Result:**
- Link previews now correctly display "day one mediagroup" as company name
- Social media sharing shows proper branding instead of generic "One Media Company"
- Improved SEO and brand consistency across all platforms
- Better link preview experience on Facebook, LinkedIn, Twitter, and other platforms